### PR TITLE
:recycle: Refactor : QR요청 실패 시 생성했던 주문 논리 삭제

### DIFF
--- a/order-service/src/main/java/com/lotfresh/orderservice/domain/orchestrator/feigns/UserFeignClient.java
+++ b/order-service/src/main/java/com/lotfresh/orderservice/domain/orchestrator/feigns/UserFeignClient.java
@@ -4,8 +4,8 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@FeignClient(name="User",url="localhost:8081/api/user")
+@FeignClient(name="User",url="localhost:8081/users")
 public interface UserFeignClient {
-    @GetMapping("/{userId}")
+    @GetMapping("/{userId}/default")
     String getProvince(@PathVariable("userId") Long userId);
 }


### PR DESCRIPTION
## MR 이유
- [x] Feature 병합
- [ ] 버그 수정(아래에 상세 기입)
- [ ] 코드 스타일 변경 (formatting, local variables ex> indentation 변경, 변수명 변경, 주석 추가 )
- [ ] 리팩터링 (로직변경 X, api 변경 X, ex> 함수 분리, 클래스 재구조화 )
- [ ] 주기적인 master 병합
- [ ] Build 관련 변경
- [ ] CI 관련 변경
- [ ] Docs 관련 변경
- [ ] 기타(아래에 상세 기입)

## 스크린샷 또는 세부 내용
- payment로의 요청이 2단계로 나뉘면서 첫 번째 요청인 QR을 받는 과정에서 실패가 발생했을 때도 Order를 delete해야 함

## MR 전 확인
- [x] 정상 작동
- [ ] Conflict 발생 - 팀원과의 상의 필요
